### PR TITLE
1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0.3](https://github.com/Okipa/laravel-failed-jobs-notifier/releases/tag/1.0.3)
+
+2019-11-20
+
+- Improved the stuck failed jobs identification in order to get them as soon as they are stuck for the configured number of days (or more).
+
 ## [1.0.2](https://github.com/Okipa/laravel-failed-jobs-notifier/releases/tag/1.0.2)
 
 2019-11-12

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Quality Score](https://img.shields.io/scrutinizer/g/Okipa/laravel-failed-jobs-notifier.svg?style=flat-square)](https://scrutinizer-ci.com/g/Okipa/laravel-failed-jobs-notifier/?branch=master)
 
 Get notified when some jobs are stuck in your `failed_jobs` table for a number of days of your choice.  
-Notifications can be sent by mail, Slack and webhooks (chats often have webhook APIs).  
+Notifications can be sent by mail, Slack and webhooks (chats often provide a webhook API).  
 
 ## Compatibility
 
@@ -57,14 +57,14 @@ php artisan vendor:publish --tag=failed-jobs-notifier:config
 Just add this command in the `schedule()` method of your `\App\Console\Kernel` class :
 
 ```php
-$schedule->command('queue:failed:notify')->dailyAt('12:00');
+$schedule->command('queue:failed:notify')->twiceDaily(9, 15);
 ```
 
 And you will be notified as soon as some jobs will be stuck in the `failed_jobs` table for the number of days you configured.
 
 ## Testing
 
-``` bash
+```bash
 composer test
 ```
 

--- a/src/FailedJobsNotifier.php
+++ b/src/FailedJobsNotifier.php
@@ -56,7 +56,7 @@ class FailedJobsNotifier
     {
         $this->checkFailedJobsTableExists();
         $daysLimit = $this->getDaysLimit();
-        $dateLimit = Carbon::now()->subDays($daysLimit)->endOfDay();
+        $dateLimit = Carbon::now()->subDays($daysLimit);
 
         return DB::table('failed_jobs')->where('failed_at', '<=', $dateLimit)->get();
     }

--- a/tests/Unit/FailedJobsNotifierTest.php
+++ b/tests/Unit/FailedJobsNotifierTest.php
@@ -95,7 +95,7 @@ class FailedJobMonitorTest extends BootstrapComponentsTestCase
         }
         config()->set('failed-jobs-notifier.daysLimit', 5);
         $stuckFailedJobs = (new FailedJobsNotifier)->getStuckFailedJobs();
-        $dateLimit = Carbon::now()->subDays(5)->endOfDay();
+        $dateLimit = Carbon::now()->subDays(5);
         foreach ($stuckFailedJobs as $stuckFailedJob) {
             $this->assertTrue($dateLimit->greaterThanOrEqualTo($stuckFailedJob->failed_at));
         }


### PR DESCRIPTION
- Improved the stuck failed jobs identification in order to get them as soon as they are stuck for the configured number of days (or more).